### PR TITLE
Quick fix for missing twitter and gplus svg icons

### DIFF
--- a/_includes/header-default.html
+++ b/_includes/header-default.html
@@ -6,8 +6,8 @@
         </h1>
         <div class="icons-home">
             <a aria-label="Send email" href="mailto:{{site.username}}"><svg class="icon icon-email"><use xlink:href="#icon-email"></use></svg></a>
-            <a aria-label="My Twitter" target="_blank" href="https://twitter.com/{{site.twitter_username}}"><svg class="icon icon-twitter"><use xlink:href="#icon-twitter"></use></svg></a>
-            <a aria-label="My Google Plus" target="_blank" href="https://plus.google.com/+{{gplus_username}}/posts"><svg class="icon icon-google-plus"><use xlink:href="#icon-google-plus"></use></svg></a>
+            <a aria-label="My Twitter" target="_blank" href="https://twitter.com/{{site.twitter_username}}"><svg class="icon"><use xlink:href="#icon-twitter"></use></svg></a>
+            <a aria-label="My Google Plus" target="_blank" href="https://plus.google.com/+{{gplus_username}}/posts"><svg class="icon"><use xlink:href="#icon-google-plus"></use></svg></a>
             <a aria-label="My Github" target="_blank" href="https://github.com/{{site.github_username}}"><svg class="icon icon-github-alt"><use xlink:href="#icon-github-alt"></use></svg></a>
             <a aria-label="Use the RSS to get updated" target="_blank" href="{{ "/feed.xml" | prepend: site.baseurl }}"><svg class="icon icon-rss"><use xlink:href="#icon-rss"></use></svg></a>
         </div>


### PR DESCRIPTION
Quick fix for missing twitter and gplus svg icons in default header....
![capture](https://cloud.githubusercontent.com/assets/6375025/10612644/4c606c32-776f-11e5-9c41-d2459bb3244d.PNG)
