### PR TITLE
Correct bug titles with apostrophe

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -9,7 +9,7 @@
     {
         disqus_loaded = true;
         var disqus_shortname = '{{site.disqus_username}}';
-        var disqus_title = '{{page.title}}';
+        var disqus_title = '{{page.title.replace("'", "\\'")}}';
         var disqus_url = '{{page.url}}';
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
         dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
When a title has an apostrophe (e.g "What's new here?") Disqus doesn't load comments. With a simple replace, the problem is fixed.
