### PR TITLE
Corrected multiple development environment problem

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,12 +15,14 @@ var messages = {
 	jekyllBuild: '<span style="color: grey">Running:</span> $ jekyll build'
 };
 
+var jekyllCommand = (/^win/.test(process.platform)) ? 'jekyll.bat' : 'jekyll';
+
 /**
  * Build the Jekyll Site
  */
 gulp.task('jekyll-build', function (done) {
 	browserSync.notify(messages.jekyllBuild);
-	return cp.spawn('jekyll', ['build'], {stdio: 'inherit'})
+	return cp.spawn(jekyllCommand, ['build'], {stdio: 'inherit'})
 		.on('close', done);
 });
 


### PR DESCRIPTION
Corrected the described problem on the readme. 

The fix which was presented works fine if you have only a windows environment, however, if you develop on both windows and unix like platforms this solution alone is just not enough. We need to identify the current platform the user is running the command to make the changes accordingly.
